### PR TITLE
site/fix siteurl for social cards

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: nixcv
-site_url: https://nixcv.nix.みんな
+site_url: https://nixcv.nix.xn--q9jyb4c
 repo_url: https://github.com/djacu/nixcv
 repo_name: djacu/nixcv
 edit_uri: tree/main/site


### PR DESCRIPTION
The social cards don't work on all platforms. I'm guessing the site_url needs to be in ascii.